### PR TITLE
Add json-to-Workfow function

### DIFF
--- a/python_workflow_definition/src/python_workflow_definition/pyiron_workflow.py
+++ b/python_workflow_definition/src/python_workflow_definition/pyiron_workflow.py
@@ -330,7 +330,7 @@ def import_from_string(library_path: str) -> Any:
 
 def build_function_dag_workflow(file_name: str) -> Workflow:
     content = remove_result(
-        PythonWorkflowDefinitionWorkflow.load_json_file(file_name="workflow.json")
+        PythonWorkflowDefinitionWorkflow.load_json_file(file_name=file_name)
     )
 
     input_values: dict[int, object] = (


### PR DESCRIPTION
@jan-janssen, I left your function in-place; this PR purely adds a new function for converting function DAG JSONs in the `python-workflow-definition` format into `pyiron_workflow.Workflow` objects.

```python
from python_workflow_definition.pyiron_workflow import build_function_dag_workflow, write_workflow_json

write_workflow_json(
  build_function_dag_workflow("workflow.json").graph_as_dict, file_name="cycled.json")
)
```

The underlying workflow runs and draws the same, and this cycle produces a JSON file identical to `pyiron_workflow_arithmetic.json` produced by the arithmetic example notebook. Hopefully that means it suits the rest of your needs.

I wasn't confident that the import routine captures more deeply nested function definitions, so I copy-pasted a routine `import_from_string` from `bagofholding`. I think it might later be a nice addition to `pyiron_snippets`, but for something so small a copy-paste here is fine.