### PR TITLE
Update pyiron_workflow to 0.19.1

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -9,7 +9,7 @@ dependencies:
 - jobflow =0.3.1
 - executorlib =1.10.1
 - pyiron_base =0.15.16
-- pyiron_workflow =0.18.0
+- pyiron_workflow =0.19.1
 - pygraphviz =1.14
 - aiida-workgraph =0.8.1
 - conda_subprocess =0.0.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ pyiron = [
     "pyiron_base>=0.11.10,<=0.15.16",
 ]
 pyiron_workflow = [
-    "pyiron_workflow>=0.13.0,<=0.18.0",
+    "pyiron_workflow>=0.13.0,<=0.19.1",
 ]
 executorlib = [
     "executorlib>=1.7.4,<=1.10.1",


### PR DESCRIPTION
@liamhuber I guess I need your help here. I was able to update to 0.18.0 as it still had the `_legacy` interface but with 0.19.X it is a whole new interface. 